### PR TITLE
feat: On mobile, moved the nav to left

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -88,6 +88,15 @@ export default function Navigation() {
               color: var(--font-color);
             }
 
+            @media (max-width: 769px) {
+              ul {
+                text-align: left;
+              }
+              li {
+                padding: 0 0 0 1.5rem;
+              }
+            }
+
             @media (min-width: 769px) {
               .container {
                 width: 7rem;


### PR DESCRIPTION
- This features the nav from right to left, to give a better UX for the user.
- This applies only to mobile devices.

Before: 
![image](https://user-images.githubusercontent.com/22195501/135947540-0bf730da-555e-4bd0-9047-5cbadfd77fc7.png)


After:
![image](https://user-images.githubusercontent.com/22195501/135947510-8842c03f-4281-4758-8d50-fa8116bea4c9.png)
